### PR TITLE
Make cpio output quiet & allow debug mode

### DIFF
--- a/scripts/bootimg.sh
+++ b/scripts/bootimg.sh
@@ -17,6 +17,7 @@ if [ "$#" == 0 ];then
 fi
 
 set -e
+[ $DEBUG -ge 1 ] && set -x
 
 if [ -f "$2" ];then
 	scr="$(readlink -f "$2")"
@@ -48,7 +49,7 @@ startBootImgEdit() {
 	cd "$d2"
 
 	if [ -f "$bootimg_extract"/ramdisk.gz ];then
-		gunzip -c < "$bootimg_extract"/ramdisk.gz |cpio -i
+		gunzip -c < "$bootimg_extract"/ramdisk.gz |cpio -i --quiet
 		gunzip -c < "$bootimg_extract"/ramdisk.gz > ramdisk1
 	else
 		echo "Unknown ramdisk format"
@@ -83,7 +84,7 @@ addFile() {
 
 doneBootImgEdit() {
 	#List of files to replace \n separated
-	echo $INITRAMFS_FILES |tr ' ' '\n' | cpio -o -H newc > ramdisk2
+	echo $INITRAMFS_FILES |tr ' ' '\n' | cpio --quiet -o -H newc > ramdisk2
 
 	if [ -f "$bootimg_extract"/ramdisk.gz ];then
 		#TODO: Why can't I recreate initramfs from scratch?
@@ -91,7 +92,7 @@ doneBootImgEdit() {
 		#Hence sepolicy/su/init.rc are our version
 		#There is a trailer in CPIO file format. Hence strip-cpio
 		rm -f cpio-*
-		"$scriptdir/bin/strip-cpio" ramdisk1 $INITRAMFS_FILES
+		"$scriptdir/bin/strip-cpio" ramdisk1 $INITRAMFS_FILES 2>/dev/null
 		cat cpio-* ramdisk2 |gzip -9 -c > "$bootimg_extract"/ramdisk.gz
 	else
 		exit 1


### PR DESCRIPTION
We don't need block level output, so adding the `--quiet` flag to the cpio
command.

We may also want to see all commands as they're run, so added a flagged call
to `set -x`

The strip-cpio binary output is very verbose, but doesn't add much value, so
redirect stderr to /dev/null.